### PR TITLE
Stop stale tracking after timeout

### DIFF
--- a/app/ObjectDetection.c
+++ b/app/ObjectDetection.c
@@ -25,7 +25,14 @@
 #define LOG_TRACE(fmt, args...) {}
 
 #define IDLE_THRESHOLD_PCT 50
-#define DIRECTION_CHANGE_THRESHOLD_RAD (M_PI / 4) // 45 degrees 
+#define DIRECTION_CHANGE_THRESHOLD_RAD (M_PI / 4) // 45 degrees
+// Evict tracks that VOD has stopped reporting. VOD normally delivers a terminal
+// active=false frame, but on tracker glitches/scene changes it can simply drop an
+// object without one. Because the tracker is republished on an independent 1s timer
+// (unlike detections, which are only emitted per VOD frame), such an orphan would be
+// republished forever at frozen coordinates. If no VOD update arrives within this
+// window, treat the object as gone.
+#define STALE_TRACKER_TIMEOUT_MS 5000
 
 typedef struct {
     char name[64];
@@ -950,6 +957,28 @@ gboolean update_trackers(gpointer user_data) {
     g_hash_table_iter_init(&iter, detectionCache);
     while (g_hash_table_iter_next(&iter, &key, &value)) {
         detection_cache_entry_t *entry = (detection_cache_entry_t*)value;
+        // Stale-track reaper: VOD has not reported this object within the timeout
+        // window. Finalize it (active=false) so downstream consumers clear it, then
+        // evict it from the cache. Without this, a dropped track is republished
+        // forever at frozen coordinates until the ACAP restarts.
+        if( now - entry->timestamp > STALE_TRACKER_TIMEOUT_MS ) {
+            if( entry->valid && entry->active ) {
+                entry->active = false;
+                bool should_publish = false;
+                cJSON *death_json = build_tracker_json(entry, 0, &should_publish);
+                if (should_publish && death_json) {
+                    tracker_callback_data_t *cb_data = malloc(sizeof(tracker_callback_data_t));
+                    if (cb_data) {
+                        cb_data->payload = cJSON_Duplicate(death_json, 1);
+                        cb_data->timer = 0;
+                        pending_callbacks = g_list_prepend(pending_callbacks, cb_data);
+                    }
+                    cJSON_Delete(death_json);
+                }
+            }
+            g_hash_table_iter_remove(&iter);
+            continue;
+        }
         if( entry->active == true && now - entry->last_published_tracker > 1500 ) {
             bool should_publish = false;
             cJSON *tracker_json = build_tracker_json(entry, 1, &should_publish);


### PR DESCRIPTION
# Problem
The tracker republish is an independent 1s timer (`update_trackers`) that re-emits every active cache entry, independent of VOD. When VOD silently drops an object without a terminal `active=false` frame, that timer republishes the orphan at frozen coordinates every 1.5s indefinitely.

*Path* implications — `ProcessPaths` finalizes a path only on an `active=false` event frame. With no such frame, the object's path stalls in `PathCache` forever: never published or stitched, and leaked until restart. 

*Detections* do not show this symptom: they're published only as a side-effect of each VOD frame, so when VOD goes quiet the detections topic simply stops. (A stale entry can briefly leak into detections only if VOD keeps reporting other objects; the reaper's cache eviction cleans that up as a side benefit.)

# Fix
Adds a stale-track reaper to update_trackers() (already running on a 1s timer). On each pass, any cache entry that VOD hasn't updated within STALE_TRACKER_TIMEOUT_MS (5000 ms) is:

Finalized — one active=false tracker payload is published so downstream consumers clear the track, and
Evicted from detectionCache, so it stops being republished on both the tracker and detections topics.
Staleness is measured via entry->timestamp, which is refreshed to now on every VOD update, so the window genuinely tracks "time since VOD last reported this object."

# Implementation notes
- Eviction during iteration uses g_hash_table_iter_remove(); callbacks fire outside the detection mutex, matching the existing pattern in update_trackers().
- The reaper only triggers when VOD didn't send a terminal frame and removes the entry in the same pass, so there's no double-publish with the normal active=false paths.
- malloc failure for the callback is handled gracefully — the entry is still evicted (worst case: one missed death publish, no leak).

# Changes
app/ObjectDetection.c: +29 / −1 — new STALE_TRACKER_TIMEOUT_MS define and reaper block in update_trackers().